### PR TITLE
Fix breakage when raising no stub specified error

### DIFF
--- a/lib/shell_mock/backtick_monkey_patch.rb
+++ b/lib/shell_mock/backtick_monkey_patch.rb
@@ -25,7 +25,7 @@ module ShellMock
         if ShellMock.let_commands_run?
           __un_shell_mocked_backtick(command)
         else
-          raise NoStubSpecified.new({}, command, {})
+          raise NoStubSpecified.new(command)
         end
       end
     end

--- a/lib/shell_mock/exec_monkey_patch.rb
+++ b/lib/shell_mock/exec_monkey_patch.rb
@@ -24,7 +24,7 @@ module ShellMock
         if ShellMock.let_commands_run?
           __un_shell_mocked_exec(env, command, options)
         else
-          raise NoStubSpecified.new(env, command, options)
+          raise NoStubSpecified.new(command)
         end
       end
     end

--- a/lib/shell_mock/no_stub_specified.rb
+++ b/lib/shell_mock/no_stub_specified.rb
@@ -1,6 +1,6 @@
 module ShellMock
   class NoStubSpecified < StandardError
-    def initialize(env, command, **options)
+    def initialize(command)
       super("no stub specified for #{command}")
     end
   end

--- a/lib/shell_mock/spawn_monkey_patch.rb
+++ b/lib/shell_mock/spawn_monkey_patch.rb
@@ -24,7 +24,7 @@ module ShellMock
         if ShellMock.let_commands_run?
           __un_shell_mocked_spawn(env, command, options)
         else
-          raise NoStubSpecified.new(env, command, options)
+          raise NoStubSpecified.new(command)
         end
       end
     end

--- a/lib/shell_mock/system_monkey_patch.rb
+++ b/lib/shell_mock/system_monkey_patch.rb
@@ -24,7 +24,7 @@ module ShellMock
         if ShellMock.let_commands_run?
           __un_shell_mocked_system(env, command, options)
         else
-          raise NoStubSpecified.new(env, command, options)
+          raise NoStubSpecified.new(command)
         end
       end
     end

--- a/spec/shell_mock/spawn_monkey_patch_spec.rb
+++ b/spec/shell_mock/spawn_monkey_patch_spec.rb
@@ -119,12 +119,27 @@ module ShellMock
           let(:output)     { 'which not found' }
           let(:exitstatus) { 42 }
 
-          before { ShellMock.stub_command(command).to_output(output).to_exit(exitstatus) }
+          context "when the command is stubbed" do
+            before { ShellMock.stub_command(command).to_output(output).to_exit(exitstatus) }
 
-          it "writes the specified output to the stdout pipe" do
-            stdin, stdout, waiter = Open3.popen2e(command)
+            it "writes the specified output to the stdout pipe" do
+              stdin, stdout, waiter = Open3.popen2e(command)
 
-            expect(stdout.read.chomp).to eq output
+              expect(stdout.read.chomp).to eq output
+            end
+          end
+
+          context "when the command is not stubbed and command execution is disabled" do
+            before do
+              ShellMock.dont_let_commands_run
+            end
+
+            it "raises an error" do
+              expect { Open3.popen2e(command) }.to raise_error(
+                NoStubSpecified,
+                "no stub specified for which which"
+              )
+            end
           end
         end
       end

--- a/spec/shell_mock/spawn_monkey_patch_spec.rb
+++ b/spec/shell_mock/spawn_monkey_patch_spec.rb
@@ -130,9 +130,7 @@ module ShellMock
           end
 
           context "when the command is not stubbed and command execution is disabled" do
-            before do
-              ShellMock.dont_let_commands_run
-            end
+            before { ShellMock.dont_let_commands_run }
 
             it "raises an error" do
               expect { Open3.popen2e(command) }.to raise_error(


### PR DESCRIPTION
This is the easiest way to "fix" this error. It is not so much a fix as a small change following the realisation that options is not needed for the error class.

Some more tests that cover all cases for the other calls/monkey patches would probably be useful .

* Command is not stubbed and let to execute
* Command is not stubbed and can not execute